### PR TITLE
Fix AudioContext start permission for Chrome autoplay policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ node make
 ```
 
 Updates
+- 22 October 2020 - Fix AudioContext creation for autoplay policy in Chrome >= 71
 - 31 July 2015 - Allow seeking in streaming web audio mode, improved player controls, added reverb and resampling
 - 21 July 2015 - Implementation of Circular Buffer Queue fixes clicks/pops/static with custom Web Audio Rendering
 - 19 July 2015 - switch to 44.1K rendering

--- a/index.html
+++ b/index.html
@@ -402,6 +402,7 @@ var files = evt.dataTransfer ? evt.dataTransfer.files : evt.target.files;
       }
 
       function runConversion() {
+        if(!audioIsInitted){initAudio();}
         convertionJob = {
           sourceMidi: 'freepats/' + midiName,
           targetWav: midiName.replace(/\.midi?$/i, '.wav'),

--- a/web_audio_player.js
+++ b/web_audio_player.js
@@ -1,7 +1,7 @@
 /*
  * Circular Web Audio Buffer Queue
  */
-function CircularAudioBuffer(slots) {
+function CircularAudioBuffer(slots, audioCtx) {
 	slots = slots || 24; // number of buffers
 	this.slots = slots;
 	this.buffers = new Array(slots);
@@ -61,17 +61,26 @@ var BUFFER = 4096; // buffer sample
 var channels = 2;
 
 // Create AudioContext and buffer source
-var audioCtx = new AudioContext();
-var source = audioCtx.createBufferSource();
-var scriptNode = audioCtx.createScriptProcessor(BUFFER, 0, channels);
+var audioCtx;
+var source;
+var scriptNode;
+var circularBuffer;
+var emptyBuffer;
+var audioIsInitted = false;
 
-var circularBuffer = new CircularAudioBuffer(4);
+function initAudio() {
+    audioCtx = new window.AudioContext();
+    scriptNode = audioCtx.createScriptProcessor(BUFFER, 0, channels);
+    scriptNode.onaudioprocess = onAudioProcess;
 
-var emptyBuffer = audioCtx.createBuffer(channels, BUFFER, SAMPLE_RATE);
+    source = audioCtx.createBufferSource();
+    circularBuffer = new CircularAudioBuffer(4, audioCtx);
+    emptyBuffer = audioCtx.createBuffer(channels, BUFFER, SAMPLE_RATE);
 
-scriptNode.onaudioprocess = onAudioProcess;
-source.connect(scriptNode);
-source.start();
+    source.connect(scriptNode);
+    source.start(0);
+}
+
 
 function startAudio() {
 	scriptNode.connect(audioCtx.destination);


### PR DESCRIPTION
Currently, in newer versions of Chrome, the demo site fails to play audio, with the following in the javascript console:

> The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page. https://goo.gl/7K7WLu

This PR fixes this.
